### PR TITLE
Update start analysis as case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ms-word-addin-speransky",
-  "version": "0.4.139",
+  "version": "0.4.140",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ms-word-addin-speransky",
-      "version": "0.4.139",
+      "version": "0.4.140",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react": "^8.118.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ms-word-addin-speransky",
-  "version": "0.4.140",
+  "version": "0.4.141",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ms-word-addin-speransky",
-      "version": "0.4.140",
+      "version": "0.4.141",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react": "^8.118.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-word-addin-speransky",
-  "version": "0.4.139",
+  "version": "0.4.140",
   "repository": {
     "type": "git",
     "url": "https://github.com/OfficeDev/Office-Addin-TaskPane-React.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-word-addin-speransky",
-  "version": "0.4.140",
+  "version": "0.4.141",
   "repository": {
     "type": "git",
     "url": "https://github.com/OfficeDev/Office-Addin-TaskPane-React.git"

--- a/src/taskpane/api/routes.ts
+++ b/src/taskpane/api/routes.ts
@@ -5,6 +5,7 @@ export const CONTRACT_ROUTES = {
   meta: (document_id: string) => `/v1/legal-case/document/${document_id}/meta`,
   recommendation: (document_id: string) => `/v1/legal-case/document/${document_id}/recommendation`,
   archive: (document_id: string) => `/v1/legal-case/document/${document_id}/archive`,
+  archiveCase: (legal_case_id: string) => `/v1/legal-case/${legal_case_id}/archive`,
 } as const;
 
 export const AUTH_CLIENT_EXISTS = "/v1/client";

--- a/src/taskpane/api/routes.ts
+++ b/src/taskpane/api/routes.ts
@@ -1,6 +1,7 @@
 export const CONTRACT_ROUTES = {
   detectType: "/v1/legal-case/detect-type",
   analyze: "/v1/legal-case/analyze",
+  analyzeCase: (legal_case_id: string) => `/v1/legal-case/${legal_case_id}/analyze`,
   meta: (document_id: string) => `/v1/legal-case/document/${document_id}/meta`,
   recommendation: (document_id: string) => `/v1/legal-case/document/${document_id}/recommendation`,
   archive: (document_id: string) => `/v1/legal-case/document/${document_id}/archive`,

--- a/src/taskpane/api/types/index.ts
+++ b/src/taskpane/api/types/index.ts
@@ -1,7 +1,9 @@
 export * from "./payload-contract-analyze-dto";
+export * from "./payload-contract-analyze-case-dto";
 export * from "./payload-contract-detect-type-dto";
 
 export * from "./response-contract-analyze-dto";
+export * from "./response-contract-analyze-case-dto";
 export * from "./response-contract-detect-type-dto";
 export * from "./response-contract-meta-dto";
 export * from "./response-contract-recommendation-dto";

--- a/src/taskpane/api/types/payload-contract-analyze-case-dto.ts
+++ b/src/taskpane/api/types/payload-contract-analyze-case-dto.ts
@@ -1,0 +1,7 @@
+export type PayloadContractAnalyzeCaseDto = {
+  llm_provider: "mistral" | "gigachat" | "openai";
+  source: "web" | "plugin";
+  selected_party?: string | null;
+  user_comment?: string | null;
+  checklist_id?: string | null;
+};

--- a/src/taskpane/api/types/response-contract-analyze-case-dto.ts
+++ b/src/taskpane/api/types/response-contract-analyze-case-dto.ts
@@ -1,0 +1,9 @@
+export interface ResponseContractAnalyzeCaseDto {
+  status: string;
+  recommendations: RecommendationDetails[];
+}
+
+interface RecommendationDetails {
+  document_id: string;
+  recommendation_id: string;
+}

--- a/src/taskpane/api/v1/contract.ts
+++ b/src/taskpane/api/v1/contract.ts
@@ -110,6 +110,28 @@ const contract = {
       signal: config?.signal,
     });
   },
+
+  /** @description Получение ZIP-архива с результатами анализа кейса */
+  archiveCase: (
+    legal_case_id: string,
+    includeReport?: boolean,
+    includeReview?: boolean,
+    includeProtocol?: boolean,
+    config?: { signal?: AbortSignal }
+  ) => {
+    return axios.get<Blob>(CONTRACT_ROUTES.archiveCase(legal_case_id), {
+      params: {
+        includeReport,
+        includeReview,
+        includeProtocol,
+      },
+      headers: {
+        Accept: "application/json",
+      },
+      responseType: "blob",
+      signal: config?.signal,
+    });
+  },
 };
 
 export default contract;

--- a/src/taskpane/api/v1/contract.ts
+++ b/src/taskpane/api/v1/contract.ts
@@ -1,8 +1,10 @@
 import axios from "../instanceAxios";
 import { CONTRACT_ROUTES } from "../routes";
 import {
+  PayloadContractAnalyzeCaseDto,
   PayloadContractAnalyzeDto,
   PayloadContractDetectTypeDto,
+  ResponseContractAnalyzeCaseDto,
   ResponseContractAnalyzeDto,
   ResponseContractDetectTypeDto,
   ResponseContractMetaDto,
@@ -45,6 +47,32 @@ const contract = {
     }
 
     return axios.post<ResponseContractAnalyzeDto>(CONTRACT_ROUTES.analyze, body, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    });
+  },
+
+  /** @description Запуск анализа договора как кейса */
+  analyzeCase: (legal_case_id: string, data: PayloadContractAnalyzeCaseDto) => {
+    const body = new URLSearchParams();
+
+    body.append("llm_provider", data.llm_provider);
+    body.append("source", data.source);
+
+    if (data.selected_party) {
+      body.append("selected_party", data.selected_party);
+    }
+
+    if (data.user_comment) {
+      body.append("user_comment", data.user_comment);
+    }
+
+    if (data.checklist_id) {
+      body.append("checklist_id", data.checklist_id);
+    }
+
+    return axios.post<ResponseContractAnalyzeCaseDto>(CONTRACT_ROUTES.analyzeCase(legal_case_id), body, {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
       },

--- a/src/taskpane/store/document.ts
+++ b/src/taskpane/store/document.ts
@@ -290,7 +290,7 @@ class DocumentStore {
     if (!this.documentId) return;
 
     try {
-      const response = await api.contract.archive(this.documentId, true, true, true);
+      const response = await api.contract.archiveCase(this.legalCaseId, true, true, true);
       const blob = response.data;
 
       const baseName = this.documentName ? this.documentName.replace(/\.docx$/i, "") : "";

--- a/src/taskpane/store/suggestions.ts
+++ b/src/taskpane/store/suggestions.ts
@@ -166,16 +166,16 @@ class SuggestionsStore {
       }
 
       const documentId = this.rootStore.documentStore.documentId;
+      const legalCaseId = this.rootStore.documentStore.legalCaseId;
       const party = this.formPartySelected;
       const userComment = this.formCustomInstructions;
       const checklistId = this.checklistId;
 
-      if (!documentId) {
+      if (!documentId || !legalCaseId) {
         throw new Error("Document not uploaded");
       }
 
       const payload = {
-        document_id: documentId,
         llm_provider: this.rootStore.menuStore.providerLLM,
         source: SourceTypeEnums.PLUGIN,
         selected_party: party || undefined,
@@ -183,7 +183,7 @@ class SuggestionsStore {
         checklist_id: checklistId || undefined,
       };
 
-      const response = await api.contract.analyze(payload);
+      const response = await api.contract.analyzeCase(legalCaseId, payload);
 
       console.log("createAnalysisTask [success]", response.data);
 


### PR DESCRIPTION
Обновление запуска анализа договора как кейса и скачивание архива результатов как кейса в связи с последующим удалением старых ручек: `/v1/legal-case/analyze` и `/v1/legal-case/document/{document_id}/archive`.